### PR TITLE
Feature api verification

### DIFF
--- a/server/modules/filter/checkBlacklistCountries.js
+++ b/server/modules/filter/checkBlacklistCountries.js
@@ -15,8 +15,7 @@ async function checkBlacklistCountries(ip) {
       return false;
     }
   } catch (error) {
-    console.log(error);
-    return false;
+    throw `ipstack GET ${error}`;
   };
 }
 


### PR DESCRIPTION
I know it looks like a small change, but it solves our problem! Throwing an error terminates the function the same way a return statement would; runFilter never gets to the point where it saves the scan info, so nothing can be scanned while the api is down, and the error is logged to the server console (when it's caught by the try-catch block in filter.js) so admins will know what happened.